### PR TITLE
Update X link to @argo_dev_

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -50,7 +50,7 @@ og_image: /assets/img/icon.jpg
 # -----------------------------------------------------------------------------
 
 twitter_username: # Deprecated; use x_username
-x_username: arugo___
+x_username: argo_dev_
 discord_id: argo___
 qiita_username: # あなたのQiita username
 


### PR DESCRIPTION
## Summary
- update `x_username` in `_config.yml` from `arugo___` to `argo_dev_`
- refresh the site-wide X/Twitter link target via the shared config value

## Verification
- local `bundle exec jekyll build` could not be completed because `bundle install` failed to reach `index.rubygems.org`
- rely on GitHub Actions triggered by this pull request for validation